### PR TITLE
feat: Add description show button to result page 

### DIFF
--- a/src/pages/question/Questions.js
+++ b/src/pages/question/Questions.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useLocation } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -244,6 +245,32 @@ function Questions() {
     window.addEventListener("mouseup", onMouseUp);
   };
 
+  const navigate = useNavigate();
+  const goSelectSolve = () => {
+    const toSolveTags = new Set();
+    const toSolveQuestions = 
+      filterQuestions.some(({ question }) => question.checked)
+      ? filterQuestions
+          .filter(({ question }) => question.checked)
+          .map(({ question }) => {
+            const { checked, id, tag, ...rest } = question;
+            if (tag) tag.forEach((t) => toSolveTags.add(t));
+            return rest;
+          })
+      : filterQuestions.map(({ question }) => {
+          const { checked, id, tag, ...rest } = question;
+          if (tag) tag.forEach((t) => toSolveTags.add(t));
+          return rest;
+        });
+
+      navigate("/select", {
+        state: {
+          selectedTags: [...toSolveTags], 
+          selectedQuestions: toSolveQuestions, 
+        },
+      });
+  }
+
   return (
     <main className="ml-20 flex">
       <Sidebar
@@ -262,6 +289,7 @@ function Questions() {
         insertButtonClick={insertButtonClick}
         handleUpdateClick={handleUpdateClick}
         handleDownloadToZip={handleDownloadToZip}
+        goSelectSolve={goSelectSolve}
       />
 
       {/* 오버레이는 모달이 열려있을 때만 렌더링 */}

--- a/src/pages/question/QuestionsMain.js
+++ b/src/pages/question/QuestionsMain.js
@@ -4,7 +4,7 @@ import { questionsAtom } from "state/data.js";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 
 
-function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, insertButtonClick, handleUpdateClick, handleDownloadToZip, deleteFilteredQuestions }) {
+function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, insertButtonClick, handleUpdateClick, handleDownloadToZip, deleteFilteredQuestions, goSelectSolve }) {
   const [isAllChecked, setIsAllChecked] = useState(false); // 전체 체크박스 상태 관리
   const questions = useRecoilValue(questionsAtom);
   const setQuestions = useSetRecoilState(questionsAtom);
@@ -87,6 +87,12 @@ function QuestionsMain({ isCollapsed, filterQuestions, setFilterQuestions, inser
           </h1>
         </div>
         <div className="bg-white items-center flex">
+          <div
+            onClick={() => goSelectSolve()}
+            className="cursor-pointer bg-blue-500 hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2"
+          >
+            문제풀러가기
+          </div>          
           <div
             onClick={() => insertButtonClick()}
             className="cursor-pointer bg-blue-500 hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2"

--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -158,7 +158,10 @@ function Card() {
       <div className="sm:rounded-lg h-full flex flex-col">
         <div className="p-4 flex justify-between border-b">
           <div>
-            <h1 className="text-2xl font-semibold">{tags.join(" ")}</h1>
+            <h1 className="text-2xl font-semibold">
+              {tags.length == 0 && "문제 풀이"}
+              {tags.length >= 0 && tags.join(" ")}              
+            </h1>
             <h1 className=" text-md font-normal text-gray-400">총 {questions.length} 문제</h1>
           </div>
         </div>

--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -12,11 +12,11 @@ function Card() {
 
   const [questionIndex, setQuestionIndex] = useState(0); // 현재 문제의 인덱스
   const location = useLocation();
-  const questions = location.state.questions;
-  const tags = location.state.tags;
+  const questions = [...location.state.questions];
+  const tags = [...location.state.tags];
   const navigate = useNavigate();
-  const today = new Date(); // 오늘 날짜 객체
-  const formattedToday = format(today, 'yyyy-MM-dd'); // 'YYYY-MM-DD' 형식으로 포맷
+  const today = new Date(); 
+  const formattedToday = format(today, 'yyyy-MM-dd'); 
 
   // Recoil 수정
   const setRecoilQuestions = useSetRecoilState(questionsAtom);
@@ -63,6 +63,8 @@ function Card() {
     const currentLevel = currentQuestion.level ? parseInt(currentQuestion.level, 10) : 0;
     const newLevel = Math.min(currentLevel + 1, 3); // 레벨 증가 (최대 3)
     const newUpdateDate = calculateUpdateDate(today, newLevel);
+
+    currentQuestion.selected = currentQuestion.answer;
 
     setCorrectCount((prevCount) => {
       const updatedCount = prevCount + 1;

--- a/src/pages/solve/CardResult.js
+++ b/src/pages/solve/CardResult.js
@@ -2,6 +2,8 @@ import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Doughnut } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -12,6 +14,29 @@ function CardResult() {
   const result = location.state.result;
   const navigate = useNavigate();
   const goCard = () => { navigate("/card", { state :  { "questions" : questions, "tags" : tags }})}
+  const retryWrongQuestions = () => { 
+    const retryTags = new Set();
+    const retryQuestions = questions.filter((item) => item.answer !== item.selected);
+    retryQuestions.forEach((item) => {
+      if (item.tag) {
+        item.tag.forEach((tag) => retryTags.add(tag));
+      }
+    });
+
+    if(retryQuestions.length <= 0) {
+      if (!toast.isActive("no-question-retry-error")) {
+        toast.error("다시 풀 문제가 없습니다!", { toastId: "no-question-retry-error" });
+      } 
+      return;
+    }
+
+    navigate("/card", { 
+      state :  { 
+        "questions" : retryQuestions, 
+        "tags" : retryTags 
+      }
+    }
+  )}
   const goDashBoard = () => { navigate("/dashboard")}
 
   
@@ -50,7 +75,10 @@ function CardResult() {
 
         <div className="hidden p-4 flex justify-between border-b">
           <div>
-            <h1 className="text-2xl font-semibold">{tags.map((tag) => tag + " ")}</h1>
+            <h1 className="text-2xl font-semibold">
+              {tags.length == 0 && "문제 결과"}
+              {tags.map((tag) => tag + " ")}
+            </h1>
             <h1 className="text-md font-normal text-gray-400">{questions.length} 문제</h1>
           </div>
         </div>
@@ -58,22 +86,32 @@ function CardResult() {
         <div className="my-auto flex-1 flex flex-col gap-2 p-10 items-center">
             <div className="flex flex-col w-3/4 h-[400px] bg-white rounded-2xl shadow flex justify-around">
               <div>
-                <div className="font-bold text-xl text-center">{tags.map((tag) => tag + " ")}</div>
+                <div className="font-bold text-xl text-center">
+                  {tags.length == 0 && "문제 결과"}
+                  {tags.map((tag) => tag + " ")}
+                </div>
                 <div className="text-sm font-semibold text-gray-400 text-center mt-1">총 {questions.length}문제 중 {result.correct}문제를 맞췄어요</div>
               </div>
               <div className="mt-2 h-1/2">
                   <Doughnut data={data} options={options} />
               </div>
               <div className="flex justify-between w-full px-5">
+                <div className="flex gap-1">
+                  <div 
+                    onClick={goCard}
+                    className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">
+                      전체 다시풀기
+                    </div>
+                  <div 
+                    onClick={retryWrongQuestions}
+                    className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">
+                      오답 다시풀기
+                  </div>
+                </div>
                 <div 
-                onClick={goCard}
-                className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">다시풀기</div>
-              
-              <div 
-                onClick={goDashBoard}
-                className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">완료</div>
-            
-              </div>
+                  onClick={goDashBoard}
+                  className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">완료</div>
+                </div>
               
             </div>
         </div>

--- a/src/pages/solve/MultipleResult.js
+++ b/src/pages/solve/MultipleResult.js
@@ -6,7 +6,7 @@ import remarkBreaks from 'remark-breaks';
 import { markdownComponents } from "utils/markdownUtils.js"
 
 
-function MultipleResult({ question, index }) {
+function MultipleResult({ question, index, isShowAllDescription }) {
   const appPath = useRecoilValue(appPathAtom);
 
   const [showModal, setShowModal] = useState(false);
@@ -105,14 +105,14 @@ function MultipleResult({ question, index }) {
           
         <div
           className={`mt-10 rounded-xl p-5 font-md bg-gray-100 w-full overflow-hidden text-clip transition-all inline-flex gap-1 ${
-            !showDescription ? "blur-sm" : "blur-none"
+            (!isShowAllDescription && !showDescription) ? "blur-sm" : "blur-none"
           }`}>
           <img src="./images/light_icon.png" 
             onClick={() => setShowDescription(false)}
             className="w-5 h-5 cursor-pointer hover:scale-110 transition-all text hover:scale-110 mr-1"/>
             {question.description}
         </div>
-        {!showDescription && (
+        {(!isShowAllDescription && !showDescription) && (
             <button
               className="mt-10 absolute inset-0 flex items-center justify-center bg-black bg-opacity-40 text-white font-bold rounded-xl"
               onClick={() => setShowDescription(true)}

--- a/src/pages/solve/SingleResult.js
+++ b/src/pages/solve/SingleResult.js
@@ -6,7 +6,7 @@ import remarkBreaks from 'remark-breaks';
 import { appPathAtom } from "state/data.js";
 import { markdownComponents } from "utils/markdownUtils.js"
 
-function SingleResult({ question, index, setQuestions }) {
+function SingleResult({ question, index, setQuestions, isShowAllDescription }) {
   const appPath = useRecoilValue(appPathAtom);
   const [showModal, setShowModal] = useState(false);
   const [isCorrect, setIsCorrect] = useState(question.answer === question.selected);
@@ -161,14 +161,14 @@ function SingleResult({ question, index, setQuestions }) {
           
           <div
           className={`mt-10 rounded-xl p-5 font-md bg-gray-100 w-full overflow-hidden text-clip transition-all inline-flex gap-1 ${
-            !showDescription ? "blur-sm" : "blur-none"
+            (!isShowAllDescription && !showDescription ) ? "blur-sm" : "blur-none"
           }`}>
           <img src="./images/light_icon.png" 
             onClick={() => setShowDescription(false)}
             className="w-5 h-5 cursor-pointer hover:scale-110 transition-all text hover:scale-110 mr-1"/>
             {question.description}
           </div>
-          {!showDescription && (
+          {(!isShowAllDescription && !showDescription) && (
             <button
               className="mt-10 absolute inset-0 flex items-center justify-center bg-black bg-opacity-40 text-white font-bold rounded-xl"
               onClick={() => setShowDescription(true)}

--- a/src/pages/solve/Solve.js
+++ b/src/pages/solve/Solve.js
@@ -175,16 +175,15 @@ function Solve() {
     (question) => question.selected && question.selected.trim() !== ""
   );
 
-  // 조건에 따른 스타일 변수들
   const isFirstQuestion = questionIndex === 0;
   const isLastQuestion = questionIndex === answers.length - 1;
 
   return (
     <main className="ml-20">
       <div className="sm:rounded-lg">
-        <div className="p-4 flex justify-between border-b">
-          <div>
-            <h1 className="text-2xl font-semibold">
+        <div className="p-4 flex justify-between items-center border-b">
+          <div className="flex-1 min-w-0">
+            <h1 className="text-2xl font-semibold truncate">
               {passedTags.length == 0 && "문제 풀이"}
               {passedTags.map((tag, idx) => (
                 <span key={idx}>{tag} </span>
@@ -194,29 +193,40 @@ function Solve() {
               총 {passedQuestions.length}문제
             </h1>
           </div>
-          
-          <div className="text-right items-center flex gap-2">
-          {initialTimer > 0 && (
-              <h1 className="text-md font-normal text-gray-400">남은시간: {formatTime(timeLeft)}</h1>
+  
+          <div className="text-right items-center flex gap-2 shrink-0">
+            {initialTimer > 0 && (
+              <h1 className="text-md font-normal text-gray-400">
+                남은시간: {formatTime(timeLeft)}
+              </h1>
             )}
+  
             <div
               onClick={() => setNavCollapse(!navCollapse)}
-              className="cursor-pointer border-2 border-gray-200 hover:bg-blue-300 hover:border-blue-300 rounded-xl p-2.5 text-center me-2 mb-2">
+              className="relative cursor-pointer border-2 border-gray-200 hover:bg-blue-300 hover:border-blue-300 rounded-xl p-2.5 text-center me-2 mb-2"
+            >
               {navCollapse && (
-                <div className='absolute right-5 top-20 bg-white shadow p-4 rounded-lg w-40 h-50'>
-                  <QuestionNav questions={passedQuestions} setQuestionIndex={setQuestionIndex}></QuestionNav>
+                <div className="absolute right-5 top-20 bg-white shadow p-4 rounded-lg w-40 h-50">
+                  <QuestionNav
+                    questions={passedQuestions}
+                    setQuestionIndex={setQuestionIndex}
+                  />
                 </div>
               )}
             </div>
+  
             <div
               onClick={submit}
-              className={`cursor-pointer ${allAnswered ? 'bg-blue-500' : 'bg-gray-400'} hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
+              className={`cursor-pointer ${
+                allAnswered ? "bg-blue-500" : "bg-gray-400"
+              } hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
             >
               제출
             </div>
           </div>
         </div>
-        {answers[questionIndex].type === '주관식' ? (
+  
+        {answers[questionIndex].type === "주관식" ? (
           <Single
             key={questionIndex}
             onAnswerChange={handleAnswerChange}
@@ -232,12 +242,14 @@ function Solve() {
           />
         )}
       </div>
+  
       <div className="fixed z-40 bottom-5 right-5 flex gap-2">
         <div
           onClick={beforeQuestion}
-          className={`rounded-full p-2 text-white ${isFirstQuestion ? 'bg-gray-400' : 'bg-blue-500'} hover:scale-105 transition shadow`}
+          className={`rounded-full p-2 text-white ${
+            isFirstQuestion ? "bg-gray-400" : "bg-blue-500"
+          } hover:scale-105 transition shadow`}
         >
-          {/* 이전 아이콘 */}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -253,12 +265,13 @@ function Solve() {
             />
           </svg>
         </div>
-
+  
         <div
           onClick={nextQuestion}
-          className={`rounded-full p-2 text-white ${isLastQuestion ? 'bg-gray-400' : 'bg-blue-500'} hover:scale-105 transition shadow cursor-pointer`}
+          className={`rounded-full p-2 text-white ${
+            isLastQuestion ? "bg-gray-400" : "bg-blue-500"
+          } hover:scale-105 transition shadow cursor-pointer`}
         >
-          {/* 다음 아이콘 */}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -277,6 +290,7 @@ function Solve() {
       </div>
     </main>
   );
+  
 }
 
 export default Solve;

--- a/src/pages/solve/SolveResult.js
+++ b/src/pages/solve/SolveResult.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { useSetRecoilState } from "recoil";
 import { Doughnut, Bar } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from "chart.js";
@@ -137,15 +137,14 @@ function SolveResult() {
   const resultPage = () => {
     return answers.map((answer, index) => {
       return answer.type === "주관식" ? (
-        <SingleResult key={index} question={answer} index={index} setQuestions={setQuestions} />
+        <SingleResult key={index} question={answer} index={index} setQuestions={setQuestions} isShowAllDescription={isShowAllDescription} />
       ) : (
-        <MultipleResult key={index} question={answer} index={index} />
+        <MultipleResult key={index} question={answer} index={index} isShowAllDescription={isShowAllDescription}/>
       );
     });
   };
 
   const navigate = useNavigate();
-
   const retryAll = () => {
     const retryTags = new Set();
     const retryQuestions = [...answers];
@@ -186,6 +185,11 @@ function SolveResult() {
   
   }
 
+  const [isShowAllDescription, setIsShowAllDescription] = useState(false); 
+  const handleShowDescriptionClick = () => {
+    setIsShowAllDescription((prev) => !prev);
+  }
+
   return (
     <main className="ml-20">
       {/* PDF 처리할 REF 설정 */}
@@ -201,37 +205,43 @@ function SolveResult() {
             </h1>
           </div>
           <div className="flex items-center">
-            {/* PDF 다운로드 버튼 */}
-          <div 
-          className="cursor-pointer bg-blue-500 hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-8 inline-flex items-center justify-center me-2 mb-2"
-
-          onClick={handleDownloadPDF}>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="1.5"
-              stroke="white"
-              className="size-4"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5Zm-3 0h.008v.008H15V10.5Z"
-              />
-            </svg>
-          </div>
           <div
+            onClick={handleShowDescriptionClick}
+            className={`cursor-pointer hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-8 inline-flex items-center justify-center me-2 mb-2 ${isShowAllDescription ? "bg-blue-500" : "bg-blue-100"}`}
+          >
+            {isShowAllDescription ? <BulbOnIcon /> : <BulbOffIcon />}
+          </div>
+
+
+            <div 
+              className="cursor-pointer bg-blue-500 hover:scale-105 transition text-white font-semibold rounded-2xl text-xs h-8 w-8 inline-flex items-center justify-center me-2 mb-2"
+              onClick={handleDownloadPDF}>
+              <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="1.5"
+                  stroke="white"
+                  className="size-4"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5Zm-3 0h.008v.008H15V10.5Z"
+                  />
+              </svg>
+            </div>
+            <div
               onClick={retryAll}
               className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
             >
               전체 다시풀기
-          </div>
+            </div>
           <div
-              onClick={retryWrongQuestions}
-              className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
-            >
-              오답 다시풀기
+            onClick={retryWrongQuestions}
+            className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
+          >
+            오답 다시풀기
           </div>
           </div>
         </div>
@@ -261,3 +271,38 @@ function SolveResult() {
 }
 
 export default SolveResult;
+
+function BulbOnIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="white"
+      className="size-4"
+      aria-hidden="true"
+    >
+      <path d="M12 2.25c-3.728 0-6.75 2.88-6.75 6.427 0 2.13 1.033 3.853 2.595 5.004.564.42.915 1.04.915 1.715v.104c0 .41.334.745.745.745h4.99c.411 0 .745-.334.745-.745v-.104c0-.676.351-1.295.915-1.715 1.562-1.151 2.595-2.874 2.595-5.004C18.75 5.13 15.728 2.25 12 2.25Z" />
+      <path d="M9 18.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Zm.75 2.25h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5Z" />
+    </svg>
+  );
+}
+
+function BulbOffIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.8"
+      stroke="white"
+      className="size-4"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.75 18h4.5M9.75 20.25h4.5M8.25 15.75c0-.8-.38-1.55-1.03-2.02A5.978 5.978 0 0 1 5.25 8.677C5.25 5.243 8.272 2.25 12 2.25s6.75 2.993 6.75 6.427a5.98 5.98 0 0 1-1.97 5.053c-.65.47-1.03 1.22-1.03 2.02m-7.5 0h7.5"
+      />
+    </svg>
+  );
+}

--- a/src/pages/solve/SolveResult.js
+++ b/src/pages/solve/SolveResult.js
@@ -2,7 +2,8 @@ import React, { useRef } from "react";
 import { useSetRecoilState } from "recoil";
 import { Doughnut, Bar } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from "chart.js";
-
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import { useNavigate, useLocation } from "react-router-dom";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
@@ -145,14 +146,31 @@ function SolveResult() {
 
   const navigate = useNavigate();
 
-  const retry = () => {
+  const retryAll = () => {
+    const retryTags = new Set();
+    const retryQuestions = [...answers];
+    
+     // 틀린 문제에서 태그 값을 Set에 추가
+    retryQuestions.forEach((item) => {
+      if (item.tag) {
+        item.tag.forEach((tag) => retryTags.add(tag)); // 중복 없이 태그 추가
+      }
+    });
+
+    navigate("/solve", {
+      state: { questions: retryQuestions, tags: [...retryTags] },
+    });
+  
+  }
+
+  const retryWrongQuestions = () => {
     const retryTags = new Set();
     const retryQuestions = answers.filter((item) => item.answer !== item.selected);
     
     if(retryQuestions.length <= 0){
-      // if (!toast.isActive("no-question-error")) {
-      //         toast.error("현재 풀이 가능한 문제가 없습니다! 문제를 생성해주세요", { toastId: "no-question-error" });
-      // } 
+      if (!toast.isActive("no-question-retry-error")) {
+        toast.error("다시 풀 문제가 없습니다!", { toastId: "no-question-retry-error" });
+      } 
       return;
     }
      // 틀린 문제에서 태그 값을 Set에 추가
@@ -167,7 +185,6 @@ function SolveResult() {
     });
   
   }
-
 
   return (
     <main className="ml-20">
@@ -205,10 +222,16 @@ function SolveResult() {
             </svg>
           </div>
           <div
-              onClick={retry}
+              onClick={retryAll}
               className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
             >
-              다시풀기
+              전체 다시풀기
+          </div>
+          <div
+              onClick={retryWrongQuestions}
+              className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
+            >
+              오답 다시풀기
           </div>
           </div>
         </div>

--- a/src/pages/solve/SolveResult.js
+++ b/src/pages/solve/SolveResult.js
@@ -191,9 +191,9 @@ function SolveResult() {
       {/* PDF 처리할 REF 설정 */}
       <div className="sm:rounded-lg flex flex-col items-center" ref={pdfRef}> 
         <div className="p-4 flex justify-between items-center border-b w-full">
-          <div>
-            <h1 className="text-2xl font-semibold overflow-hidden text-ellipsis">
-            {tags.length == 0 && "문제 풀이 결과"}
+          <div className="flex-1 min-w-0">
+            <h1 className="w-full truncate text-2xl font-semibold overflow-hidden">
+              {tags.length == 0 && "문제 풀이 결과"}
               {tags.map((tag) => `${tag} `)}
             </h1>
             <h1 className="text-md font-normal text-gray-400">


### PR DESCRIPTION
<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->
문제 결과 페이지에서 해설 모두 보기 버튼 추가

## #️⃣ 관련 이슈
<!-- 
관련된 이슈 번호를 링크하거나 언급해주세요.
예: Closes #12, #34
-->
#17 

## 📝 작업 내용
<!-- 
이번 PR에서 작업한 내용을 항목별로 설명해주세요(이미지 첨부 가능)
예:
- 로그인 API (`POST /api/login`) 추가
- JWT 토큰 발급 로직 구현
- UserService 리팩토링
-->
- 해설 모두 열기 버튼 추가
![result-description-button](https://github.com/user-attachments/assets/eb8f35ac-be04-4779-864c-9b1f846f5abf)

## ✅ 테스트 결과
<!-- 
직접 테스트한 내용이나 결과를 작성해주세요.
예:
- [x] 정상 로그인 시 토큰 발급 확인
- [x] 잘못된 비밀번호로 401 응답 확인
-->
- [x] 빌드테스트 완료
- [x] 버튼 활성화 시 모든 해설이 열리는지 확인

## 💬 리뷰 요구사항(선택)
<!-- 
리뷰어가 이해를 위해 알아야 할 점, 
혹은 후속작업이 필요한 항목,
특별히 봐주었으면 하는 부분이 있다면 작성해주세요
예: 
메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
기존 보안 로직을 변경했으므로 side effect 가능성 있음
-->
