### PR TITLE
feat: Add tooltips to titles and improve retry button behavior on result pages

### DIFF
--- a/src/pages/solve/Card.js
+++ b/src/pages/solve/Card.js
@@ -160,10 +160,15 @@ function Card() {
       <div className="sm:rounded-lg h-full flex flex-col">
         <div className="p-4 flex justify-between border-b">
           <div>
-            <h1 className="text-2xl font-semibold">
-              {tags.length == 0 && "문제 풀이"}
-              {tags.length >= 0 && tags.join(" ")}              
-            </h1>
+            <div className="relative group w-full">
+                  <h1 className="truncate text-2xl font-semibold overflow-hidden">
+                    {tags.length === 0 && "문제 풀이 결과"}
+                    {tags.map((tag) => `${tag} `)}
+                  </h1>
+                  <span className="absolute top-full left-0 mt-1 hidden group-hover:block bg-gray-800 text-white text-sm rounded px-2 py-1 whitespace-pre-wrap z-10">
+                    {tags.length === 0 ? "문제 풀이 결과" : tags.join(" ")}
+                  </span>
+              </div>
             <h1 className=" text-md font-normal text-gray-400">총 {questions.length} 문제</h1>
           </div>
         </div>

--- a/src/pages/solve/CardResult.js
+++ b/src/pages/solve/CardResult.js
@@ -80,9 +80,14 @@ function CardResult() {
         <div className="my-auto flex-1 flex flex-col gap-2 p-10 items-center">
             <div className="flex flex-col w-3/4 h-[400px] bg-white rounded-2xl shadow flex justify-around">
               <div>
-                <div className="font-bold text-xl text-center">
-                  {tags.length == 0 && "문제 결과"}
-                  {tags.map((tag) => tag + " ")}
+                <div className="relative group w-full px-5">
+                  <h1 className="truncate text-2xl font-semibold overflow-hidden">
+                    {tags.length === 0 && "문제 풀이 결과"}
+                    {tags.map((tag) => `${tag} `)}
+                  </h1>
+                  <span className="absolute top-full left-0 mt-1 hidden group-hover:block bg-gray-800 text-white text-sm rounded px-2 py-1 whitespace-pre-wrap z-10">
+                    {tags.length === 0 ? "문제 풀이 결과" : tags.join(" ")}
+                  </span>
                 </div>
                 <div className="text-sm font-semibold text-gray-400 text-center mt-1">총 {questions.length}문제 중 {result.correct}문제를 맞췄어요</div>
               </div>
@@ -93,13 +98,13 @@ function CardResult() {
                 <div className="flex gap-1">
                   <button 
                     onClick={goCard}
-                    className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">
+                    className="font-semibold cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white text-xs text-center hover:shadow hover:scale-105 transition ">
                       전체 다시풀기
                     </button>
                   <button 
                     onClick={retryWrongQuestions}
                     disabled={retryQuestions.length === 0}
-                    className={`font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center text-white justify-center me-2 mb-2 transition 
+                    className={`font-semibold rounded-2xl text-xs py-2 w-20 inline-flex items-center text-white justify-center transition 
                       ${retryQuestions.length === 0 
                         ? "bg-blue-100" 
                         : "bg-blue-500 hover:scale-105 cursor-pointer"}`}
@@ -109,7 +114,7 @@ function CardResult() {
                 </div>
                 <div 
                   onClick={goDashBoard}
-                  className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">완료</div>
+                  className="font-semibold cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white text-xs text-center hover:shadow hover:scale-105 transition ">완료</div>
                 </div>
               
             </div>

--- a/src/pages/solve/CardResult.js
+++ b/src/pages/solve/CardResult.js
@@ -14,22 +14,16 @@ function CardResult() {
   const result = location.state.result;
   const navigate = useNavigate();
   const goCard = () => { navigate("/card", { state :  { "questions" : questions, "tags" : tags }})}
-  const retryWrongQuestions = () => { 
-    const retryTags = new Set();
-    const retryQuestions = questions.filter((item) => item.answer !== item.selected);
-    retryQuestions.forEach((item) => {
-      if (item.tag) {
-        item.tag.forEach((tag) => retryTags.add(tag));
-      }
-    });
-
-    if(retryQuestions.length <= 0) {
-      if (!toast.isActive("no-question-retry-error")) {
-        toast.error("다시 풀 문제가 없습니다!", { toastId: "no-question-retry-error" });
-      } 
-      return;
+  
+  const retryTags = new Set();
+  const retryQuestions = questions.filter((item) => item.answer !== item.selected);
+  retryQuestions.forEach((item) => {
+    if (item.tag) {
+      item.tag.forEach((tag) => retryTags.add(tag));
     }
+  });    
 
+  const retryWrongQuestions = () => { 
     navigate("/card", { 
       state :  { 
         "questions" : retryQuestions, 
@@ -97,16 +91,21 @@ function CardResult() {
               </div>
               <div className="flex justify-between w-full px-5">
                 <div className="flex gap-1">
-                  <div 
+                  <button 
                     onClick={goCard}
                     className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">
                       전체 다시풀기
-                    </div>
-                  <div 
+                    </button>
+                  <button 
                     onClick={retryWrongQuestions}
-                    className="cursor-pointer bg-blue-500 rounded-2xl py-2 w-20 whitespace-nowrap text-white font-bold text-xs text-center hover:shadow hover:scale-105 transition ">
-                      오답 다시풀기
-                  </div>
+                    disabled={retryQuestions.length === 0}
+                    className={`font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center text-white justify-center me-2 mb-2 transition 
+                      ${retryQuestions.length === 0 
+                        ? "bg-blue-100" 
+                        : "bg-blue-500 hover:scale-105 cursor-pointer"}`}
+                  >
+                  오답 다시풀기
+                  </button>
                 </div>
                 <div 
                   onClick={goDashBoard}

--- a/src/pages/solve/Solve.js
+++ b/src/pages/solve/Solve.js
@@ -183,12 +183,15 @@ function Solve() {
       <div className="sm:rounded-lg">
         <div className="p-4 flex justify-between items-center border-b">
           <div className="flex-1 min-w-0">
-            <h1 className="text-2xl font-semibold truncate">
-              {passedTags.length == 0 && "문제 풀이"}
-              {passedTags.map((tag, idx) => (
-                <span key={idx}>{tag} </span>
-              ))}
+          <div className="relative group w-full">
+            <h1 className="truncate text-2xl font-semibold overflow-hidden">
+              {passedTags.length === 0 && "문제 풀이"}
+              {passedTags.map((tag) => `${tag} `)}
             </h1>
+            <span className="absolute top-full left-0 mt-1 hidden group-hover:block bg-gray-800 text-white text-sm rounded px-2 py-1 whitespace-pre-wrap z-10">
+              {passedTags.length === 0 ? "문제 풀이" : passedTags.join(" ")}
+            </span>
+          </div>
             <h1 className="text-md font-normal text-gray-400">
               총 {passedQuestions.length}문제
             </h1>

--- a/src/pages/solve/SolveResult.js
+++ b/src/pages/solve/SolveResult.js
@@ -162,27 +162,18 @@ function SolveResult() {
   
   }
 
-  const retryWrongQuestions = () => {
-    const retryTags = new Set();
-    const retryQuestions = answers.filter((item) => item.answer !== item.selected);
-    
-    if(retryQuestions.length <= 0){
-      if (!toast.isActive("no-question-retry-error")) {
-        toast.error("다시 풀 문제가 없습니다!", { toastId: "no-question-retry-error" });
-      } 
-      return;
+  const retryTags = new Set();
+  const retryQuestions = answers.filter((item) => item.answer !== item.selected);
+  retryQuestions.forEach((item) => {
+    if (item.tag) {
+      item.tag.forEach((tag) => retryTags.add(tag)); // 중복 없이 태그 추가
     }
-     // 틀린 문제에서 태그 값을 Set에 추가
-    retryQuestions.forEach((item) => {
-      if (item.tag) {
-        item.tag.forEach((tag) => retryTags.add(tag)); // 중복 없이 태그 추가
-      }
-    });
-
+  });
+  
+  const retryWrongQuestions = () => {
     navigate("/solve", {
       state: { questions: retryQuestions, tags: [...retryTags] },
     });
-  
   }
 
   const [isShowAllDescription, setIsShowAllDescription] = useState(false); 
@@ -231,18 +222,22 @@ function SolveResult() {
                   />
               </svg>
             </div>
-            <div
+            <button
               onClick={retryAll}
-              className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
+              className={`cursor-pointer border-[1.5px] border-blue-500 hover:scale-105 text-blue-500 font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
             >
               전체 다시풀기
-            </div>
-          <div
-            onClick={retryWrongQuestions}
-            className={`cursor-pointer bg-blue-500 hover:scale-105 text-white font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center justify-center me-2 mb-2 transition`}
-          >
-            오답 다시풀기
-          </div>
+            </button>
+            <button
+              onClick={retryWrongQuestions}
+              disabled={retryQuestions.length === 0}
+              className={`font-semibold rounded-2xl text-xs h-8 w-24 inline-flex items-center text-white justify-center me-2 mb-2 transition 
+                ${retryQuestions.length === 0 
+                  ? "bg-blue-100" 
+                  : "bg-blue-500 hover:scale-105 cursor-pointer"}`}
+            >
+              오답 다시풀기
+            </button>
           </div>
         </div>
 

--- a/src/pages/solve/SolveResult.js
+++ b/src/pages/solve/SolveResult.js
@@ -187,10 +187,15 @@ function SolveResult() {
       <div className="sm:rounded-lg flex flex-col items-center" ref={pdfRef}> 
         <div className="p-4 flex justify-between items-center border-b w-full">
           <div className="flex-1 min-w-0">
-            <h1 className="w-full truncate text-2xl font-semibold overflow-hidden">
-              {tags.length == 0 && "문제 풀이 결과"}
+          <div className="relative group w-full">
+            <h1 className="truncate text-2xl font-semibold overflow-hidden">
+              {tags.length === 0 && "문제 풀이 결과"}
               {tags.map((tag) => `${tag} `)}
             </h1>
+            <span className="absolute top-full left-0 mt-1 hidden group-hover:block bg-gray-800 text-white text-sm rounded px-2 py-1 whitespace-pre-wrap z-10">
+              {tags.length === 0 ? "문제 풀이 결과" : tags.join(" ")}
+            </span>
+          </div>
             <h1 className="text-md font-normal text-gray-400">
               총 {answers.length}문제
             </h1>


### PR DESCRIPTION

<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->


## #️⃣ 관련 이슈
- #21 
- #22 

## 📝 작업 내용
- Solve / SolveResult / Card / CardResult 페이지 제목에 툴팁 추가
  - 태그가 길어져 말줄임(...) 처리될 경우를 대비하여 hover 시 전체 태그 노출
<img width="1773" height="1186" alt="image" src="https://github.com/user-attachments/assets/e8725fa9-77e1-4c1d-9ba1-8c2f56c6de46" />
<img width="1773" height="1190" alt="image" src="https://github.com/user-attachments/assets/31c458b8-41f7-46df-b1ec-4cb25f761663" />
<img width="1777" height="1187" alt="image" src="https://github.com/user-attachments/assets/50fc53f1-713f-411b-9f01-7e0b1dfc35aa" />


- SolveResult / CardResult 페이지 '다시풀기' 버튼 UX 개선

  - 오답이 없는 경우 버튼을 disabled 처리
  기존 onClick 이벤트 내에서 return 하여 예외처리 하던 것을,  브라우저 차원에서 아예 버튼 자체를 disabled 처리하여 불필요한 이벤트 호출을 줄이고 안정성을 높였습니다. 

  - 비활성 상태일 때 색상 스타일 변경
사용자에게 직관적으로 버튼이 비활성 상태임을 안내합니다.

<img width="1770" height="1182" alt="image" src="https://github.com/user-attachments/assets/61aaff4b-8f53-43cc-b4d6-e66dc1221f2b" />
<img width="1779" height="1193" alt="image" src="https://github.com/user-attachments/assets/fa21a24b-2b41-451d-b5ed-c2aed8bdf687" />
<img width="1773" height="1193" alt="image" src="https://github.com/user-attachments/assets/44038e0d-0e92-4b9e-9adc-38d00e03ac79" />



## ✅ 테스트 결과
- [x] 빌드테스트 완료
- [x] 각 페이지에서 제목에 대한 툴팁이 잘 적용되는 지 확인
- [x] 문제 결과 페이지에서 다시 풀 문제가 없을 때, '다시풀기' 버튼이 비활성화되는지 확인
- [x] 일부 문제를 틀린 경우 버튼이 정상적으로 활성화되는지 확인

## 💬 리뷰 요구사항(선택)