### PR TITLE
feat: When checkbox is selected, Item Darken the color

### DIFF
--- a/src/pages/question/QuestionItem.js
+++ b/src/pages/question/QuestionItem.js
@@ -11,7 +11,7 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
   const tag = tags.map((tagName, index) => (
     <span
       key={index}
-      className="font-medium text-xs whitespace-nowrap bg-gray-200 rounded-xl py-1 px-2"
+      className="font-medium text-xs whitespace-nowrap bg-gray-300 rounded-xl py-1 px-2"
     >
       {tagName}
     </span>
@@ -184,7 +184,7 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
     <>
       <tr
         onClick={toggle}
-        className={`${!isCollapsed && "border-b hover:shadow"} transition-all `}
+        className={`${!isCollapsed && "hover:shadow"} ${isChecked ? "bg-gray-200" : "bg-gray-50"} transition-all `}
       >
         <td className="w-4 p-4 align-top py-4 px-8">
           <div className="flex items-center ">
@@ -232,9 +232,9 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
         </td>
       </tr>
       <tr
-        className={` hover:shadow transition-all duration-500 ${
+        className={` border-b hover:shadow transition-all duration-500 ${
           isCollapsed ? "border-b" : ""
-        }`}
+        } ${isChecked ? "bg-gray-200" : "bg-gray-50"}`}
       >
         <td></td>
         <td className="overflow-hidden">
@@ -328,6 +328,8 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
               </div>
             )}
           </div>
+        </td>
+        <td class="px-3 py-2 align-top">
         </td>
       </tr>
       {showModal && (

--- a/src/pages/question/QuestionItem.js
+++ b/src/pages/question/QuestionItem.js
@@ -184,7 +184,7 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
     <>
       <tr
         onClick={toggle}
-        className={`${!isCollapsed && "hover:shadow"} ${isChecked ? "bg-gray-200" : "bg-gray-50"} transition-all `}
+        className={`${isChecked ? "bg-gray-200" : "bg-gray-50"} transition-all`}
       >
         <td className="w-4 p-4 align-top py-4 px-8">
           <div className="flex items-center ">
@@ -232,9 +232,8 @@ function QuestionItem({ question, onUpdateClick, handleCheckboxChange }) {
         </td>
       </tr>
       <tr
-        className={` border-b hover:shadow transition-all duration-500 ${
-          isCollapsed ? "border-b" : ""
-        } ${isChecked ? "bg-gray-200" : "bg-gray-50"}`}
+        className={` ${isChecked ? "bg-gray-200" : "bg-gray-50"} border-b
+        } `}
       >
         <td></td>
         <td className="overflow-hidden">


### PR DESCRIPTION
<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->


## #️⃣ 관련 이슈
- #24 

## 📝 작업 내용
- 문제가 `checkbox`로 선택 된 경우 가시성을 위해 색상을 표시했습니다.
  - `item`의 색상을 `gray-50` -> `gray-200`으로 수정했습니다.
- `item`에 있는 `tag`의 색상을 다른 컨포넌트의 색상들과 통일 시켰습니다.
  - `tag`의 색상을 `gray-200` 에서 `gray-300`으로 통일 했습니다.
- **문제 제목** `tr`에 있는 밑줄 `border-b`을 제거하고 **문제 정보** `tr`에 `border-b`를 추가하였습니다.

<img width="1054" height="561" alt="스크린샷 2025-09-02 오후 6 30 39" src="https://github.com/user-attachments/assets/92f0c471-4b2a-40e7-8897-956feecdc215" />


## ✅ 테스트 결과
- [x] 빌드테스트 완료
- [x] 문제 선택시 색상 변경이 잘 되는지 확인했습니다.

## 💬 리뷰 요구사항(선택)
기존 에니메이션 `hover:shadow`를 제거했습니다. `border-b`를 문제 보기로 옮겨 상단 문제 제목 **hover 시 부자연스러운 애니메이션이**라 판단했습니다.
또한 `duration` 으로 인해 `checkbox` selected 시 **색상 변경에도 영향**을 미쳐 고민해 지우는 방향으로 생각했습니다.
